### PR TITLE
add cal.com meeting scheduler in contact section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -96,7 +96,7 @@ facebook_id: # your facebook id
 discord_id: # your discord id (18-digit unique numerical identifier)
 
 contact_note: >
-  You can contact me <strong>anytime</strong> about anything, but I don't promise the <em>best</em> (most accurate) or the <em>expected</em> (what you might like to hear) response.
+  You can contact me <a href="https://cal.com/nikronic">anytime</a> about anything, but I don't promise the <em>best</em> (most accurate) or the <em>expected</em> (what you might like to hear) response.
   If I have not responded within <strong>48 hours</strong>, please send a reminder (prioritize based on the given order).<br>
   <strong>Order of availability</strong>: Email >>> Telegram > Twitter (I barely check messages)
   


### PR DESCRIPTION
just add https://cal.com/nikronic for meeting scheduling and availability. Since I am working full time and cannot have meeting during it, I just put it there for those to need to actually have a meeting asap. That is why it is just sitting on a single keyword in contact section, for those who actually are eager enough. Maybe doing this puzzle thing is stupid, but email is obvious way of doing it and I always respond to emails. 