### PR TITLE
fix broken/irrelevant links

### DIFF
--- a/_news/announcement_4.md
+++ b/_news/announcement_4.md
@@ -6,7 +6,7 @@ inline: false
 giscus_comments: true
 ---
 
-I gave a oral talk as the 10-min opener about <a href="{{site.baseurl}}/news/announcement_2">my recent publication</a> at <a href="toronto-geometry-colloquium.github.io">Toronto Geometry Colloquium</a> which is part of <a href="https://www.dgp.toronto.edu">Dynamic Graphics Project</a> lab at University of Toronto.
+I gave a oral talk as the 10-min opener about <a href="{{site.baseurl}}/news/announcement_2">my recent publication</a> at <a href="https://toronto-geometry-colloquium.github.io">Toronto Geometry Colloquium</a> which is part of <a href="https://www.dgp.toronto.edu">Dynamic Graphics Project</a> lab at University of Toronto.
 
 ---
 

--- a/_pages/about_einstein.md
+++ b/_pages/about_einstein.md
@@ -1,4 +1,4 @@
-Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.webp` and put it in the `img/` folder.
+Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://example.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.webp` and put it in the `img/` folder.
 
 Put your address / P.O. box / other info right below your picture. You can also disable any these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
 

--- a/_projects/5_project.md
+++ b/_projects/5_project.md
@@ -29,7 +29,7 @@ My contributions include:
     <li>Mentoring students, particularly those with non-STEM background toward utilizing AI in other fields of science</li>
 </ul>
 
-You can find more info on <a href="https://github.com/rasht-school-of-ai">Github</a> and the <a href="http://schoolofai.ir">website (in Persian)</a>
+You can find more info on <a href="https://github.com/rasht-school-of-ai">Github</a>. ~~and the <a href="http://schoolofai.ir">website (in Persian)</a>~~
 
 #### Acknowledgement
 

--- a/_projects/6_project.md
+++ b/_projects/6_project.md
@@ -21,4 +21,4 @@ PyTorch forum is a place to discuss topics around PyTorch framework and deep lea
 
 Since November 2018 that I started deep learning with PyTorch, I read topics around my questions. Later, I tried to answer questions around topics that I was not familiar with and it helped me to dive deeper into the framework, learn many of tricks and return the favor!<br> At the time of writing, <strong>I've 563 posted replies and have 184 solutions (rank 15 out of 50000+).</strong>
 
-You can find more info on the <a href="https://discuss.pytorch.org/u/nikronic/summary">Summary</a> page or <a href="https://discuss.pytorch.org/u?order=likes_received&period=all">Ordered users</a> (All time). Also, A cool <a href="https://twitter.com/ThomasViehmann/status/1309794697049714689">tweet</a> about my contribution by Thomas Viehmann. :smile:
+You can find more info on the <a href="https://discuss.pytorch.org/u/nikronic/summary">Summary</a> page or <a href="https://discuss.pytorch.org/u?order=likes_received&period=all">Ordered users</a> (All time). Also, A cool <a href="https://x.com/ThomasViehmann/status/1309794697049714689">tweet</a> about my contribution by Thomas Viehmann. :smile:


### PR DESCRIPTION
Now, the only broken links are for *ImageMagic*'s scaled images, which I don't care why they are failing. Visually things are fine with responsive images, and I am not into going deep in this regard due to the extreme level of limited time I have.

PS: I wanted to delete the entire workflow of checks for broken links as it resulted in a big cross sign, while in fact the website is deployed and works just fine. Unfortunately, GitHub is busy with features that no one wants (Timeline), yet doesn't work on a feature that all competitors have and people have been constantly requesting it for 5 years (https://github.com/actions/runner/issues/2347).